### PR TITLE
fix: 한글 채팅 시 마지막 글자 중복 출력 오류 해결

### DIFF
--- a/src/components/post/Chat/index.tsx
+++ b/src/components/post/Chat/index.tsx
@@ -95,6 +95,11 @@ const Chat: React.FC = () => {
   const handleEnterKey = (
     e: React.KeyboardEvent<HTMLTextAreaElement>
   ): void => {
+    // 한글이 조합 중일 때 엔터 키 중복 적용 방지.
+    if (e.nativeEvent.isComposing) {
+      return;
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();


### PR DESCRIPTION
## 작업 내용
한글 채팅 입력 후 enter 키를 이용한 입력 시 마지막 글자가 한번 더 출력되는 오류 해결

## 상세 작업 내용
- 한글 결합 시 enter 키 입력 이벤트 방지

## 관련 이슈
#167
