### PR TITLE
fix: 마이페이지 프로필 이미지 처리 로직 수정

### DIFF
--- a/src/components/myPage/ProfileImage/index.tsx
+++ b/src/components/myPage/ProfileImage/index.tsx
@@ -31,7 +31,12 @@ export const ProfileImg: React.FC<ProfileImageProps> = ({
 
   return (
     <ProfileImage>
-      <img src={profileImage.toString() || defaultImg} alt="프로필 이미지" />
+      <img
+        src={
+          profileImage && profileImage.trim() !== '' ? profileImage : defaultImg
+        }
+        alt="프로필 이미지"
+      />
       <button
         aria-label="프로필 이미지 수정"
         onClick={handleProfileImageUploadButtonClick}

--- a/src/components/myPage/ProfileImage/index.tsx
+++ b/src/components/myPage/ProfileImage/index.tsx
@@ -5,10 +5,10 @@ import { BsImageFill } from 'react-icons/bs';
 import { ProfileImageProps } from '../../../models/MyPage';
 import { useTheme } from '@emotion/react';
 
-export const ProfileImg: React.FC<ProfileImageProps> = (
+export const ProfileImg: React.FC<ProfileImageProps> = ({
   profileImage,
-  patchUserProfileImage
-) => {
+  patchUserProfileImage,
+}) => {
   const theme = useTheme();
   const profileImageUploadRef = React.useRef<HTMLInputElement>(null);
 


### PR DESCRIPTION
## 작업 내용
프로필 사진이 없을 때 처리 로직 수정

## 상세 작업 내용
- ProfileImg.tsx에서 props를 올바르게 구조 분해하여 사용
- MyPage.tsx에서 profileImage가 undefined일 경우 ""로 처리
- profileImage가 null이거나 ""일 경우 기본 이미지로 대체하도록 수정
- .toString() 사용을 피하고, trim()을 활용하여 빈 값 처리

## 관련 이슈
#172 
